### PR TITLE
update 2020-05-14

### DIFF
--- a/docs/DataV/components/borderBox11/src/main.vue
+++ b/docs/DataV/components/borderBox11/src/main.vue
@@ -245,10 +245,15 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'border-box-11',
-      filterId: `border-box-11-filterId-${timestamp}`,
+      filterId: `border-box-11-filterId-${uuid}`,
 
       defaultColor: ['#8aaafb', '#1f33a2'],
 

--- a/docs/DataV/components/borderBox12/src/main.vue
+++ b/docs/DataV/components/borderBox12/src/main.vue
@@ -113,10 +113,15 @@ export default {
     }
   },
   data () {
-    const timestamp = +new Date()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'border-box-12',
-      filterId: `borderr-box-12-filterId-${timestamp}`,
+      filterId: `borderr-box-12-filterId-${uuid}`,
 
       defaultColor: ['#2e6099', '#7ce7fd'],
 

--- a/docs/DataV/components/borderBox8/src/main.vue
+++ b/docs/DataV/components/borderBox8/src/main.vue
@@ -92,12 +92,17 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'border-box-8',
-      path: `border-box-8-path-${timestamp}`,
-      gradient: `border-box-8-gradient-${timestamp}`,
-      mask: `border-box-8-mask-${timestamp}`,
+      path: `border-box-8-path-${uuid}`,
+      gradient: `border-box-8-gradient-${uuid}`,
+      mask: `border-box-8-mask-${uuid}`,
 
       defaultColor: ['#235fa7', '#4fd2dd'],
 

--- a/docs/DataV/components/borderBox9/src/main.vue
+++ b/docs/DataV/components/borderBox9/src/main.vue
@@ -144,12 +144,17 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'border-box-9',
 
-      gradientId: `border-box-9-gradient-${timestamp}`,
-      maskId: `border-box-9-mask-${timestamp}`,
+      gradientId: `border-box-9-gradient-${uuid}`,
+      maskId: `border-box-9-mask-${uuid}`,
 
       defaultColor: ['#11eefd', '#0078d2'],
 

--- a/docs/DataV/components/charts/src/main.vue
+++ b/docs/DataV/components/charts/src/main.vue
@@ -19,10 +19,15 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
-      ref: `charts-container-${timestamp}`,
-      chartRef: `chart-${timestamp}`,
+      ref: `charts-container-${uuid}`,
+      chartRef: `chart-${uuid}`,
 
       chart: null
     }

--- a/docs/DataV/components/decoration10/src/main.vue
+++ b/docs/DataV/components/decoration10/src/main.vue
@@ -162,17 +162,22 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'decoration-10',
 
-      animationId1: `d10ani1${timestamp}`,
-      animationId2: `d10ani2${timestamp}`,
-      animationId3: `d10ani3${timestamp}`,
-      animationId4: `d10ani4${timestamp}`,
-      animationId5: `d10ani5${timestamp}`,
-      animationId6: `d10ani6${timestamp}`,
-      animationId7: `d10ani7${timestamp}`,
+      animationId1: `d10ani1${uuid}`,
+      animationId2: `d10ani2${uuid}`,
+      animationId3: `d10ani3${uuid}`,
+      animationId4: `d10ani4${uuid}`,
+      animationId5: `d10ani5${uuid}`,
+      animationId6: `d10ani6${uuid}`,
+      animationId7: `d10ani7${uuid}`,
 
       defaultColor: ['#00c2ff', 'rgba(0, 194, 255, 0.3)'],
 

--- a/docs/DataV/components/decoration9/src/main.vue
+++ b/docs/DataV/components/decoration9/src/main.vue
@@ -106,11 +106,16 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'decoration-9',
 
-      polygonId: `decoration-9-polygon-${timestamp}`,
+      polygonId: `decoration-9-polygon-${uuid}`,
 
       svgWH: [100, 100],
 

--- a/docs/DataV/components/flylineChart/src/main.vue
+++ b/docs/DataV/components/flylineChart/src/main.vue
@@ -171,14 +171,19 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'dv-flyline-chart',
       unique: Math.random(),
-      maskId: `flyline-mask-id-${timestamp}`,
-      maskCircleId: `mask-circle-id-${timestamp}`,
-      gradientId: `gradient-id-${timestamp}`,
-      gradient2Id: `gradient2-id-${timestamp}`,
+      maskId: `flyline-mask-id-${uuid}`,
+      maskCircleId: `mask-circle-id-${uuid}`,
+      gradientId: `gradient-id-${uuid}`,
+      gradient2Id: `gradient2-id-${uuid}`,
 
       defaultConfig: {
         /**

--- a/docs/DataV/components/flylineChartEnhanced/src/main.vue
+++ b/docs/DataV/components/flylineChartEnhanced/src/main.vue
@@ -173,12 +173,17 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'dv-flyline-chart-enhanced',
       unique: Math.random(),
-      flylineGradientId: `flyline-gradient-id-${timestamp}`,
-      haloGradientId: `halo-gradient-id-${timestamp}`,
+      flylineGradientId: `flyline-gradient-id-${uuid}`,
+      haloGradientId: `halo-gradient-id-${uuid}`,
       /**
        * @description Type Declaration
        * 

--- a/docs/DataV/components/percentPond/src/main.vue
+++ b/docs/DataV/components/percentPond/src/main.vue
@@ -57,10 +57,15 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
-      gradientId1: `percent-pond-gradientId1-${timestamp}`,
-      gradientId2: `percent-pond-gradientId2-${timestamp}`,
+      gradientId1: `percent-pond-gradientId1-${uuid}`,
+      gradientId2: `percent-pond-gradientId2-${uuid}`,
 
       width: 0,
       height: 0,

--- a/docs/DataV/components/waterLevelPond/src/main.vue
+++ b/docs/DataV/components/waterLevelPond/src/main.vue
@@ -53,9 +53,14 @@ export default {
     default: () => ({})
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
-      gradientId: `water-level-pond-${timestamp}`,
+      gradientId: `water-level-pond-${uuid}`,
 
       defaultConfig: {
         /**


### PR DESCRIPTION
**解决通过时间戳生成id导致页面border样式渲染有误的bug**
如图：
![2020-05-15_082718](https://user-images.githubusercontent.com/12559428/81999157-e598c580-9686-11ea-801c-5ab0d263a0fb.png)

   通过时间戳生成id，当页面存在多个border的时候，比如我工作中，在一个页面中使用到了5个大小不一的<dv-border-box-8>标签，有时会出现两个相同的id，如图所示，最后两个id相同，但是绘制的长宽度不同，因而导致页面渲染有误，因此改用uuid标志标签的id。